### PR TITLE
fix : Fix storeInfo header store name width

### DIFF
--- a/src/components/StoreDisplay/StoreBasicInfo/StoreBasicInfo.styles.ts
+++ b/src/components/StoreDisplay/StoreBasicInfo/StoreBasicInfo.styles.ts
@@ -65,7 +65,7 @@ export const ConvInfo = styled.div`
   padding: 0 25px;
 
   h1 {
-    min-width: 480px;
+    width: 100%;
     font-size: 2.5rem;
     font-weight: bold;
     color: #7d53d6;
@@ -90,6 +90,7 @@ export const ConvInfo = styled.div`
     padding: 0 15px;
     h1 {
       font-size: 1.6rem;
+      padding-right: 70px;
     }
     p {
       font-size: 14px;
@@ -108,6 +109,7 @@ export const ConvInfo = styled.div`
     padding: 0 10px;
     h1 {
       font-size: 1.2rem;
+      padding-right: 0;
     }
     p {
       font-size: 12px;


### PR DESCRIPTION
편의점 상세랑 작성페이지에서 편의점 이름 min-width 설정이  media-screen 에 따라 계속 유지되어서 
옆에 공백이 생겨서 스타일만 간단히 수정했습니다.  확인후 이상없으면 승인해주세요 